### PR TITLE
fix: image sizing and remove custom excerpts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
       "xs": {
         "width": 100
       },
+      "profile": {
+        "width": 150
+      },
       "s": {
         "width": 300
       },

--- a/post.hbs
+++ b/post.hbs
@@ -25,10 +25,6 @@ into the {body} tag of the default.hbs template --}}
 
         <h1 class="article-title">{{title}}</h1>
 
-        {{#if custom_excerpt}}
-            <p class="article-excerpt">{{custom_excerpt}}</p>
-        {{/if}}
-
         <div class="article-byline">
         <section class="article-byline-content">
 

--- a/post.hbs
+++ b/post.hbs
@@ -8,7 +8,7 @@ into the {body} tag of the default.hbs template --}}
 {{!-- Everything inside the #post block pulls data from the post --}}
 
 <main id="site-main" class="site-main">
-<article class="article {{post_class}} image-full">
+<article class="article {{post_class}}">
 
     <header class="article-header gh-canvas">
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This fixes feature image sizing for posts so that they're closer to the final built version. It also enables 150w profile images that we use for JAMstack News, and should help us improve Lighthouse scores a in places where we use 150px wide images.

Finally, this also removes custom excerpts from post previews, which has caused some confusion for editors.